### PR TITLE
Fix: term definition for Hashtag type

### DIFF
--- a/miscellany.jsonld
+++ b/miscellany.jsonld
@@ -2,6 +2,7 @@
   "@context": {
     "as": "https://www.w3.org/ns/activitystreams#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "Hashtag": "as:Hashtag",
     "manuallyApprovesFollowers": {
       "@id": "as:manuallyApprovesFollowers",
       "@type": "xsd:boolean"
@@ -13,10 +14,6 @@
     "sensitive": {
       "@id": "as:sensitive",
       "@type": "xsd:boolean"
-    },
-    "Hashtag": {
-      "@id": "as:Hashtag",
-      "@type": "@id"
     }
   }
 }


### PR DESCRIPTION
types/classes are conventionally defined first, before property definitions. also, Hashtag is not a property that points to a graph node, nor is it a property at all, so the usage of `@type: @id` was inappropriate.